### PR TITLE
修復浮水印影印的問題

### DIFF
--- a/ntuthesis.cls
+++ b/ntuthesis.cls
@@ -682,7 +682,7 @@
         \begin{tikzpicture}[remember picture, overlay]
           \coordinate (WM) at ([xshift=-4.325cm, yshift=-4.325cm] current page.north east);
           \node [scale=1] at (WM) {\includegraphics[width=3.65cm, height=3.65cm]{#2}};
-          \filldraw [fill=white, opacity=1-\the\numexpr#1] (current page.north east) rectangle (current page.south west);
+          \fill [fill=white, opacity=1-\the\numexpr#1] (current page.north east) rectangle (current page.south west);
         \end{tikzpicture}
       \vfill
 }}}}


### PR DESCRIPTION
以下 PDF 是原本的版本，可以看到上下界印出來都有一條線。
![before](https://user-images.githubusercontent.com/32999887/192988124-02448771-f280-45eb-a552-e6e8edd2a645.png)


修改後的 PDF 如下，可以看到上下界的線不見了。
![after](https://user-images.githubusercontent.com/32999887/192988250-bbd2d772-526c-431a-83c4-563fc5c6fc3b.png)